### PR TITLE
HotFix: LineSplitter not Working

### DIFF
--- a/src/main/java/mantenimiento/codecounter/models/comparators/ProyectComparator.java
+++ b/src/main/java/mantenimiento/codecounter/models/comparators/ProyectComparator.java
@@ -94,24 +94,14 @@ public class ProyectComparator {
         this.contentToCompareFiles.remove(javaFileToCompare);
     }
 
-    /**
-     * Genera un reporte para un archivo que está presente solo en uno de los proyectos.
-     * 
-     * @param status   estado de la línea (nuevo o eliminado)
-     * @param javaFile archivo para generar el reporte
-     * @param mention  etiqueta de versión
-     */
     private void generateReportForSingleFile(STATUS status, JavaFile javaFile, String mention) {
-        List<LineRecord> report = new ArrayList<>();
-    
-        javaFile.getContent().forEach(lineContent -> {
-            LineRecord originalRecord = new LineRecord(status, lineContent);     
-            List<LineRecord> processedLines = LineSplitter.splitLongLines(originalRecord);
-            report.addAll(processedLines);
-        });
-    
-        generalReport.put(javaFile.getFileName() + " " + mention, report);
-    }
+    List<LineRecord> report = new ArrayList<>();
+    // Sin LineSplitter: se añaden líneas originales
+    javaFile.getContent().forEach(lineContent -> {
+        report.add(new LineRecord(status, lineContent));
+    });
+    generalReport.put(javaFile.getFileName() + mention, report);
+}
 
     /**
      * Obtiene el reporte general de comparación entre ambos proyectos.

--- a/src/main/java/mantenimiento/codecounter/models/reporters/TxtReporter.java
+++ b/src/main/java/mantenimiento/codecounter/models/reporters/TxtReporter.java
@@ -15,6 +15,7 @@ import static mantenimiento.codecounter.models.comparators.STATUS.*;
 
 import mantenimiento.codecounter.demo.LineRecord;
 import mantenimiento.codecounter.models.comparators.STATUS;
+import mantenimiento.codecounter.utils.LineSplitter;
 
 /**
  * Genera reportes en formato TXT con los resultados de la comparación de archivos Java.
@@ -146,19 +147,23 @@ public class TxtReporter {
      * @throws IOException Si ocurre un error al escribir el archivo
      */
     private void writeSingleFileReport(BufferedWriter writer, 
-                                     Map.Entry<String, List<LineRecord>> fileEntry) throws IOException {
-        String fileName = fileEntry.getKey();
-        List<LineRecord> records = fileEntry.getValue();
+                                 Map.Entry<String, List<LineRecord>> fileEntry) throws IOException {
+    String fileName = fileEntry.getKey();
+    List<LineRecord> records = fileEntry.getValue();
 
-        writer.write("=== ARCHIVO " + fileName + " ===");
-        writer.newLine();
-        writer.newLine();
+    writer.write("=== ARCHIVO " + fileName + " ===");
+    writer.newLine();
+    writer.newLine();
 
-        for (LineRecord record : records) {
-            writer.write(String.format("[%s] %s", record.status(), record.content()));
+    for (LineRecord record : records) {
+        // Dividir aquí (solo para visualización)
+        List<LineRecord> displayLines = LineSplitter.splitLongLines(record);
+        for (LineRecord displayLine : displayLines) {
+            writer.write(String.format("[%s] %s", displayLine.status(), displayLine.content()));
             writer.newLine();
         }
     }
+}
 
     /**
      * Genera un reporte comparativo entre dos versiones del mismo archivo.
@@ -167,27 +172,28 @@ public class TxtReporter {
      * @throws IOException Si ocurre un error al escribir el archivo
      */
     private void writeComparisonReport(BufferedWriter writer,
-                                     List<Map.Entry<String, List<LineRecord>>> versions) throws IOException {
-        versions.sort((a, b) -> a.getKey().contains("Version: A") ? -1 : 1);
+                                 List<Map.Entry<String, List<LineRecord>>> versions) throws IOException {
+    versions.sort((a, b) -> a.getKey().contains("Version: A") ? -1 : 1);
+    String baseName = versions.get(0).getKey().replaceAll(" \\[Version: [AB]\\]", "");
+    
+    writer.write("=== COMPARACIÓN PARA " + baseName + " ===");
+    writer.newLine();
+    writer.newLine();
 
-        String baseName = versions.get(0).getKey().replaceAll(" \\[Version: [AB]\\]", "");
-        
-        writer.write("=== COMPARACIÓN PARA " + baseName + " ===");
+    for (Map.Entry<String, List<LineRecord>> version : versions) {
+        String versionLabel = version.getKey().contains("Version: A") ? "VERSIÓN ANTIGUA" : "VERSIÓN NUEVA";
+        writer.write("--- " + versionLabel + " ---");
         writer.newLine();
-        writer.newLine();
 
-        for (Map.Entry<String, List<LineRecord>> version : versions) {
-            String versionLabel = version.getKey().contains("Version: A") ? "VERSIÓN ANTIGUA" : "VERSIÓN NUEVA";
-            
-            writer.write("--- " + versionLabel + " ---");
-            writer.newLine();
-
-            for (LineRecord record : version.getValue()) {
-                writer.write(String.format("[%s] %s", record.status(), record.content()));
+        for (LineRecord record : version.getValue()) {
+            // Aplica LineSplitter aquí también
+            List<LineRecord> displayLines = LineSplitter.splitLongLines(record);
+            for (LineRecord displayLine : displayLines) {
+                writer.write(String.format("[%s] %s", displayLine.status(), displayLine.content()));
                 writer.newLine();
             }
-            
-            writer.newLine();
         }
+        writer.newLine();
     }
+}
 }


### PR DESCRIPTION
LineSplitter implementation wasn't working, now its implemented on TxtReporter instead of ProyectComparator since the split of the lineas was meant to be only a visual change and don't interfere with the global changes summary